### PR TITLE
Extend blocksapi

### DIFF
--- a/blocksapi/cursor.proto
+++ b/blocksapi/cursor.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+package borealis.blocksapi;
+
+import "blocksapi/message.proto";
+
+message GetCursorPositionRequest {
+    string stream_name = 1;
+    // Optional clarification in case if there are multiple streams with same name but from different sources
+    string stream_origin = 2;
+    string cursor_name = 3;
+}
+
+message GetCursorPositionResponse {
+    message Result {
+        BlockMessage.ID message_id = 1;
+    }
+    message Error {
+        enum Kind {
+            // Default error kind
+            UNKNOWN = 0;
+            // No such stream
+            STREAM_NOT_FOUND = 1;
+            // No such cursor
+            CURSOR_NOT_FOUND = 2;
+        }
+        Kind kind = 1;
+        string description = 2;
+    }
+    oneof response {
+        Result result = 1;
+        Error error = 2;
+    }
+}

--- a/blocksapi/message.proto
+++ b/blocksapi/message.proto
@@ -20,10 +20,15 @@ message BlockMessage {
         PAYLOAD_AURORA_BLOCK_V2 = 1;
         // protobuf (block headers + block shards)
         PAYLOAD_NEAR_BLOCK_V3 = 2;
+        // JSON (block headers separately, shards separately), classic Lake-compatible format
+        PAYLOAD_NEAR_BLOCK_V4 = 3;
+        // JSON (whole blocks)
+        PAYLOAD_AURORA_BLOCK_V3 = 4;
     }
     enum Compression {
         COMPRESSION_NONE = 0;
         COMPRESSION_ZSTD = 1;
+        COMPRESSION_ZSTD_WITH_DICTS = 2;
     }
 
     ID id = 1;
@@ -33,6 +38,9 @@ message BlockMessage {
     oneof payload {
         bytes raw_payload = 4;
     }
+
+    // Little-endian number containing first 8 bytes of SHA-3 256 hash of used compression dictionary
+    optional fixed64 zstd_dict_sha3_hash = 5;
 }
 
 message BlockMessageDeliverySettings {

--- a/blocksapi/services.proto
+++ b/blocksapi/services.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package borealis.blocksapi;
 
+import "blocksapi/cursor.proto";
 import "blocksapi/read_message.proto";
 import "blocksapi/stream_list.proto";
 import "blocksapi/stream.proto";
@@ -35,5 +36,15 @@ service BlocksWriter {
             latency of writes that depend on each other) in contrast to
             requests/responses model where each request can be routed to a separate
             backend in case of load-balancing.
+    */
+}
+
+service CursorProvider {
+    // Provides information about current cursor position
+
+    rpc GetCursorPosition(GetCursorPositionRequest) returns (GetCursorPositionResponse);
+
+    /*
+        Cursors are needed to track relevant state of streams progression
     */
 }

--- a/blocksapi/stream.proto
+++ b/blocksapi/stream.proto
@@ -38,9 +38,9 @@ message ReceiveBlocksRequest {
         START_ON_EARLIEST_AVAILABLE = 0;
         // Start on latest available message
         START_ON_LATEST_AVAILABLE = 1;
-        // Start exactly on target, return error if no such target
+        // Start exactly on target, return error if no such target (and it's not a skip-block)
         START_EXACTLY_ON_TARGET = 2;
-        // Start on message which comes exactly after target, return error if no such target
+        // Start on message which comes exactly after target, return error if no such target (and it's not a skip-block)
         START_EXACTLY_AFTER_TARGET = 3;
         // Start on earliest available message that is greater or equal to target
         START_ON_CLOSEST_TO_TARGET = 4;
@@ -69,6 +69,8 @@ message ReceiveBlocksRequest {
     }
 
     string stream_name = 1;
+    // Optional clarification in case if there are multiple streams with same name but from different sources
+    string stream_origin = 9;
 
     StartPolicy start_policy = 2;
     optional BlockMessage.ID start_target = 3;
@@ -81,13 +83,15 @@ message ReceiveBlocksRequest {
     CatchupPolicy catchup_policy = 7;
     // If not provided - default delivery settings are used during catchup
     optional BlockStreamDeliverySettings catchup_delivery_settings = 8;
+
+    // Each hash is little-endian number containing first 8 bytes of SHA-3 256 hash of used compression dictionary
+    repeated fixed64 cached_zstd_dicts_sha3_hashes = 10;
 }
 
 message ReceiveBlocksResponse {
     message Result {
         BlockMessage message = 1;
         bool catchup_in_progress = 2;
-        // TODO: maybe add auxiliary info that helps understanding distance to latest block
     }
     message Done {
         string description = 1;
@@ -107,9 +111,15 @@ message ReceiveBlocksResponse {
         Kind kind = 1;
         string description = 2;
     }
+    message ZstdDictionary {
+        bytes data = 1;
+        // Little-endian number containing first 8 bytes of SHA-3 256 hash of data. Used as dictionary identifier
+        fixed64 sha3_hash = 2;
+    }
     oneof response {
         Result message = 1;
         Done done = 2;
         Error error = 3;
+        ZstdDictionary zstd_dict = 4;
     }
 }

--- a/blocksapi/write.proto
+++ b/blocksapi/write.proto
@@ -7,6 +7,8 @@ import "blocksapi/message.proto";
 message WriteBlocksRequest {
     message WriteMessage {
         string stream_name = 1;
+        // Optional clarification in case if there are multiple streams with same name but from different sources
+        string stream_origin = 4;
         BlockMessage message = 2;
         string feedback_id = 3;
     }
@@ -46,6 +48,7 @@ message WriteBlocksResponse {
         }
 
         string stream_name = 1;
+        string stream_origin = 7;
         uint64 write_sequence = 2;
         string feedback_id = 3;
         BlockMessage.ID message_id = 4;


### PR DESCRIPTION
- Add possibility of reading a stream cursor
- Add plain JSON payload types for aurora and near blocks
- Add support for dict-based zstd compression
- Add possibility to specify stream origin to handle potential ambiguity
- Improve a few comments